### PR TITLE
Optimized image loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,60 +178,15 @@ h2.section-title {
 <script src="https://unpkg.com/imagesloaded@4/imagesloaded.pkgd.min.js"></script>
 <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
 <script>
-document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener('DOMContentLoaded', () => {
 
-  // Функция выбора цвета рейтинга
   function getRatingColor(avg){
-    if(avg>7.9) return '#186b40';
-    if(avg>6.9) return '#1978b3';
-    if(avg>4.9) return '#5369a2';
+    if(avg > 7.9) return '#186b40';
+    if(avg > 6.9) return '#1978b3';
+    if(avg > 4.9) return '#5369a2';
     return '#666e75';
   }
 
-  // Создание карточки игры
-  function createGameDiv(game){
-    const div = document.createElement('div');
-    div.className = 'game';
-
-    const ratingColor = getRatingColor(game.average);
-
-    // Цвет для сложности игры
-    let weightColor = '#5bda98';
-    if(game.averageweight>4) weightColor='#df4751';
-    else if(game.averageweight>3) weightColor='#ff6b26';
-
-    const rank = game.overallrank ?? '—';
-
-    // Прокси для изображений (WebP и кэширование)
-    const proxiedUrl = `https://images.weserv.nl/?url=${encodeURIComponent(game.image)}&w=100%25&output=webp`;
-
-    // Вставляем HTML карточки
-    div.innerHTML = `
-      <img src="${proxiedUrl}" alt="${game.name}" onerror="this.src='${game.image}'">
-      <div class="overlay">
-        <div class="overlay-content">
-          <div class="rating-hex" style="background-color:${ratingColor}">${game.average.toFixed(1)}</div>
-          <div class="title-rank">
-            <div class="title"><a href="${game.url}" target="_blank">${game.name}</a></div>
-            <div class="rank"><i class="fi-crown"></i> ${rank}</div>
-          </div>
-        </div>
-        <div class="info">
-          <p><i class="fi-torso"></i> ${game.minplayers}–${game.maxplayers}</p>
-          <p><i class="fi-clock"></i> ${game.playingtime} min</p>
-          <p><i class="fi-puzzle"></i> <span style="color:${weightColor}">${game.averageweight !== null ? game.averageweight.toFixed(2) : 'N/A'}</span> / 5</p>
-        </div>
-        <div class="info-column">
-          <p>Players: ${game.minplayers}–${game.maxplayers}</p>
-          <p>Playing time: ${game.playingtime} min</p>
-          <p>Complexity: <span style="color:${weightColor}">${game.averageweight !== null ? game.averageweight.toFixed(2) : 'N/A'}</span> / 5</p>
-        </div>
-      </div>
-    `;
-    return div;
-  }
-
-  // Количество колонок в Masonry в зависимости от ширины
   function getColumnCount(){
     if(window.innerWidth < 600) return 2;
     if(window.innerWidth < 900) return 3;
@@ -239,70 +194,168 @@ document.addEventListener('DOMContentLoaded', () => {
     return 5;
   }
 
-  // Настройка Masonry
+  const fullImageObserver = new IntersectionObserver(
+    entries => {
+      entries.forEach(entry => {
+        if(!entry.isIntersecting) return;
+
+        const img = entry.target;
+        if(img.dataset.fullLoaded) return;
+
+        const fullImg = new Image();
+        fullImg.decoding = 'async';
+        fullImg.src = img.dataset.full;
+
+        fullImg.onload = () => {
+          img.src = img.dataset.full;
+          img.dataset.fullLoaded = '1';
+        };
+
+        fullImageObserver.unobserve(img);
+      });
+    },
+    { rootMargin: '200px' }
+  );
+
+  function createGameDiv(game, container){
+    const div = document.createElement('div');
+    div.className = 'game';
+
+    const ratingColor = getRatingColor(game.average);
+
+    let weightColor = '#5bda98';
+    if(game.averageweight > 4) weightColor = '#df4751';
+    else if(game.averageweight > 3) weightColor = '#ff6b26';
+
+    const rank = game.overallrank ?? '—';
+
+    const dpr = window.devicePixelRatio || 1;
+    const colWidth = Math.ceil(container.clientWidth / getColumnCount() * dpr);
+
+    const thumbSource = game.thumbnail || game.image;
+    const thumbWidth = Math.min(colWidth, 320);
+
+    const thumbUrl =
+      `https://images.weserv.nl/?url=${encodeURIComponent(thumbSource)}&w=${thumbWidth}&q=80&output=webp`;
+
+    const fullUrl =
+      `https://images.weserv.nl/?url=${encodeURIComponent(game.image)}&w=${colWidth}&q=90&output=webp`;
+
+    div.innerHTML = `
+      <img
+        src="${thumbUrl}"
+        data-full="${fullUrl}"
+        loading="lazy"
+        decoding="async"
+        alt="${game.name}"
+      >
+      <div class="overlay">
+        <div class="overlay-content">
+          <div class="rating-hex" style="background-color:${ratingColor}">
+            ${game.average.toFixed(1)}
+          </div>
+          <div class="title-rank">
+            <div class="title">
+              <a href="${game.url}" target="_blank">${game.name}</a>
+            </div>
+            <div class="rank"><i class="fi-crown"></i> ${rank}</div>
+          </div>
+        </div>
+        <div class="info">
+          <p><i class="fi-torso"></i> ${game.minplayers}–${game.maxplayers}</p>
+          <p><i class="fi-clock"></i> ${game.playingtime} min</p>
+          <p>
+            <i class="fi-puzzle"></i>
+            <span style="color:${weightColor}">
+              ${game.averageweight !== null ? game.averageweight.toFixed(2) : 'N/A'}
+            </span> / 5
+          </p>
+        </div>
+        <div class="info-column">
+          <p>Players: ${game.minplayers}–${game.maxplayers}</p>
+          <p>Playing time: ${game.playingtime} min</p>
+          <p>
+            Complexity:
+            <span style="color:${weightColor}">
+              ${game.averageweight !== null ? game.averageweight.toFixed(2) : 'N/A'}
+            </span> / 5
+          </p>
+        </div>
+      </div>
+    `;
+
+    const img = div.querySelector('img');
+    img.onerror = () => img.src = game.image;
+
+    fullImageObserver.observe(img);
+
+    return div;
+  }
+
   function layoutMasonry(container){
     const colCount = getColumnCount();
     const colWidth = container.clientWidth / colCount;
 
-    // Присваиваем ширину каждой карточке
     container.querySelectorAll('.game').forEach(el => {
       el.style.width = colWidth + 'px';
     });
 
-    // Инициализация Masonry
     return new Masonry(container, {
       itemSelector: '.game',
       columnWidth: colWidth,
       gutter: 0,
-      percentPosition: false,
       transitionDuration: '0.4s'
     });
   }
 
-  // Загрузка игр из JSON
   function loadGames(file, containerId){
     const container = document.getElementById(containerId);
-    if(!container) return console.warn('Container not found:', containerId);
+    if(!container) return;
 
-    fetch(file)
+    return fetch(file)
       .then(res => res.json())
       .then(data => {
-        // Выбор раздела по ID контейнера
-        const games = data[containerId==='ownMosaic'?'own':containerId==='preMosaic'?'preordered':'wishlist'];
+        const games =
+          data[
+            containerId === 'ownMosaic'
+              ? 'own'
+              : containerId === 'preMosaic'
+              ? 'preordered'
+              : 'wishlist'
+          ];
 
-        // Создаем и добавляем карточки
-        games.forEach(game => container.appendChild(createGameDiv(game)));
+        games.forEach(game =>
+          container.appendChild(createGameDiv(game, container))
+        );
 
-        // Masonry после загрузки изображений
         imagesLoaded(container, () => {
           const msnry = layoutMasonry(container);
 
-          // Анимация появления карточек
-          container.querySelectorAll('.game').forEach((el,i)=>{
-            setTimeout(()=>el.classList.add('show'), 100*i);
+          container.querySelectorAll('.game').forEach((el, i) => {
+            setTimeout(() => el.classList.add('show'), 80 * i);
           });
 
-          // Скрываем лоадскрин
-          const loader = document.getElementById('loader');
-          if(loader) loader.style.display='none';
+          document.getElementById('loader')?.remove();
 
-          // Обновление Masonry при изменении размера окна
           window.addEventListener('resize', () => {
             const newColWidth = container.clientWidth / getColumnCount();
-            container.querySelectorAll('.game').forEach(el => el.style.width = newColWidth + 'px');
+            container.querySelectorAll('.game').forEach(el => {
+              el.style.width = newColWidth + 'px';
+            });
             msnry.options.columnWidth = newColWidth;
             msnry.layout();
           });
         });
-      })
-      .catch(err => console.error('Failed to load games:', err));
+      });
   }
 
-  // Загрузка всех разделов
-  loadGames('data/games.json','ownMosaic');
-  loadGames('data/games.json','preMosaic');
-  loadGames('data/games.json','wishMosaic');
+  async function loadAll(){
+    await loadGames('data/games.json', 'ownMosaic');
+    await loadGames('data/games.json', 'preMosaic');
+    await loadGames('data/games.json', 'wishMosaic');
+  }
 
+  loadAll();
 });
 </script>
 


### PR DESCRIPTION
Close #01

## Summary of changes
- Implemented two-stage image loading (lightweight thumbnail first, full image loaded via IntersectionObserver).
- Added adaptive image sizing based on container width and device pixel ratio to avoid overfetching.
- Enabled lazy loading and async decoding for all images.
- Switched all images to optimized WebP via proxy, significantly reducing total image payload.
- Improved LCP and overall load time by reducing network pressure during initial render.
- Preserved existing UI, layout, and animations; changes affect only loading strategy.

## Impact
```plaintext
| Metric             |   Before |   After |      Δ |
|--------------------|----------|---------|--------|
| FCP (ms)           |      364 |     332 |    -32 |
| LCP (ms)           |    10748 |    2604 |  -8144 |
| Load complete (ms) |    13681 |    6283 |  -7398 |
| Image bytes (KB)   |    97862 |   12098 | -85764 |
```
The data was measured using a script `test.py`. 

<details>
<summary><strong><code>test.py</code>:</strong></summary>

The script:

```python
# /// script
# dependencies = [
#   "playwright>=1.44",
#   "tabulate>=0.9.0"
# ]
# requires-python = ">=3.11"
# ///

import asyncio
import time
from tabulate import tabulate
from playwright.async_api import async_playwright

FILES = {
    "baseline": "http://localhost:8000/index.html",
    "fast": "http://localhost:8000/index-fast.html",
}

async def measure(browser, url):
    context = await browser.new_context()
    page = await context.new_page()

    client = await context.new_cdp_session(page)
    await client.send("Network.enable")
    await client.send("Network.setCacheDisabled", {"cacheDisabled": True})

    image_bytes = 0

    async def on_response(response):
        nonlocal image_bytes
        if (
            response.request.resource_type == "image"
            and response.ok
            and "content-length" in response.headers
        ):
            image_bytes += int(response.headers["content-length"])

    page.on("response", on_response)

    start = time.perf_counter()

    await page.goto(url, wait_until="load")

    perf = await page.evaluate("""
        () => new Promise(resolve => {
            const metrics = { fcp: null, lcp: null }

            new PerformanceObserver(list => {
                const entry = list.getEntries()[0]
                metrics.fcp = entry.startTime
            }).observe({ type: "paint", buffered: true })

            new PerformanceObserver(list => {
                const entries = list.getEntries()
                metrics.lcp = entries[entries.length - 1].startTime
            }).observe({ type: "largest-contentful-paint", buffered: true })

            setTimeout(() => resolve(metrics), 3000)
        })
    """)

    end = time.perf_counter()

    await context.close()

    return {
        "FCP (ms)": round(perf["fcp"]) if perf["fcp"] else None,
        "LCP (ms)": round(perf["lcp"]) if perf["lcp"] else None,
        "Load complete (ms)": round((end - start) * 1000),
        "Image bytes (KB)": round(image_bytes / 1024),
    }

async def main():
    async with async_playwright() as p:
        browser = await p.chromium.launch(headless=True)

        results = {}
        for name, url in FILES.items():
            results[name] = await measure(browser, url)

        rows = []
        for metric in results["baseline"]:
            before = results["baseline"][metric]
            after = results["fast"][metric]

            if before is None or after is None:
                delta = "n/a"
            else:
                delta = f"{after - before:+}"

            rows.append([metric, before, after, delta])

        print(tabulate(
            rows,
            headers=["Metric", "Before", "After", "Δ"],
            tablefmt="github"
        ))

        await browser.close()

asyncio.run(main())

```

Run with [`uv`](https://docs.astral.sh/uv/):

```sh
uv run test.py
```

Before running a script, starting a web server. Simply, in root project dir run:

```python
python -m http.server
```

</details>

Happy birthday! :birthday: :partying_face: :balloon: 